### PR TITLE
Added support for light debugging of badges

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"html/template"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/kataras/iris"
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/russross/blackfriday"
 )
 
 func init() {
@@ -20,18 +24,42 @@ func init() {
 	}
 }
 
+type Badge struct {
+	BadgesHTML template.HTML
+	Badge      string
+}
+
 func main() {
+	iris.Static("/badges", "./badges/", 1)
 	iris.Get("/github.com/:username/:reponame", func(ctx *iris.Context) {
 		username := ctx.Param("username")
 		reponame := ctx.Param("reponame")
 		queryString := ctx.URI().QueryArgs()
-		logrus.Debug("branch: %v", string(queryString.Peek("branch")))
-		badge, err := checkBadges(username, reponame, string(queryString.Peek("branch")))
+		branch := string(queryString.Peek("branch"))
+		debug := string(queryString.Peek("debug"))
+
+		logrus.Debug("branch: %v - debug: %v", branch, debug)
+		badges, err := checkBadges(username, reponame, branch)
 		if err != nil {
 			ctx.Write(err.Error())
 			ctx.SetStatusCode(iris.StatusInternalServerError)
 		}
-		ctx.ServeFile(badge, false)
+		if debug == "true" {
+			htmlBadges := blackfriday.MarkdownBasic([]byte(strings.Join(badges[1:], "\n")))
+			htmlBadges = bluemonday.UGCPolicy().SanitizeBytes(htmlBadges)
+			if len(htmlBadges) == 0 {
+				htmlBadges = []byte("<p><em>No badges found in README.md</em></p>")
+			}
+
+			if err := ctx.Render("index.html", Badge{
+				BadgesHTML: template.HTML(string(htmlBadges)),
+				Badge:      badges[0],
+			}); err != nil {
+				logrus.Panic(err)
+			}
+		} else {
+			ctx.ServeFile(badges[0], false)
+		}
 	})
 
 	logrus.Info("Server listening on :8080")

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Badge Badge - Debug</title>
+</head>
+<body>
+  <h2>Badge(s) found</h2>
+  {{ .BadgesHTML }}
+  <h2>Repo Badge Earned</h2>
+  <img src="/{{ .Badge}}" alt="Badge Badge" />
+</body>
+</html>

--- a/validate.go
+++ b/validate.go
@@ -17,26 +17,28 @@ const adequateBadge = "badges/adequate.svg"
 
 var badgeRex = regexp.MustCompile("(?i)(\\[!\\[[a-zA-Z0-9_ ]*\\]\\([0-9a-z.\\/:?=-]*\\)\\]\\([0-9a-z.\\/:-]*\\))")
 
-func checkBadges(username string, reponame string, branch string) (string, error) {
+func checkBadges(username string, reponame string, branch string) ([]string, error) {
+	githubRepo := fmt.Sprintf("github.com/%s/%s", username, reponame)
 	if branch == "" {
 		branch = "master"
 	}
 	resp, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/README.md", username, reponame, branch))
 	if err != nil {
 		// handle error
-		logrus.Fatalf("could not fetch: %v", err)
+		logrus.Debugf("could not fetch github repo: %s - err: %v", githubRepo, err)
+		return []string{}, err
 	}
 	logrus.Debug("resp: ", resp)
 	if resp.StatusCode != 200 {
-		logrus.Debugf("Github repo %s not found", fmt.Sprintf("github.com/%s/%s", username, reponame))
-		return "", errors.New("github repo/branch not found")
+		logrus.Debugf("Github repo %s not found", githubRepo)
+		return []string{}, errors.New("github repo/branch not found")
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		// handle error
-		logrus.Debugf("could not read body from %s: %v", fmt.Sprintf("github.com/%s/%s", username, reponame), err)
-		return "", err
+		logrus.Debugf("could not read body from %s: %v", githubRepo, err)
+		return []string{}, err
 	}
 	logrus.Debug("body: ", string(body))
 
@@ -46,10 +48,10 @@ func checkBadges(username string, reponame string, branch string) (string, error
 	badgeMatch := badgeRex.FindAllString(string(body), -1)
 	logrus.Debug(badgeMatch)
 	logrus.Infof("Badge count: %v - min: %v", len(badgeMatch), badgeMinimum)
-	if len(badgeMatch) > badgeMinimum {
+	if len(badgeMatch) >= badgeMinimum {
 		logrus.Info("Congrats you haz all badges")
-		return adequateBadge, nil
+		return append([]string{adequateBadge}, badgeMatch...), nil
 	}
 	logrus.Info("Needz moar badges")
-	return inadequateBadge, nil
+	return append([]string{inadequateBadge}, badgeMatch...), nil
 }


### PR DESCRIPTION
Added simple template for badge debugging via `debug=true` - Fixes #2
Signed-off-by: French Ben frenchben@docker.com
