### PR TITLE
Added report as the url to hit to show debugging as well

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,38 +31,44 @@ type Badge struct {
 
 func main() {
 	iris.Static("/badges", "./badges/", 1)
-	iris.Get("/github.com/:username/:reponame", func(ctx *iris.Context) {
-		username := ctx.Param("username")
-		reponame := ctx.Param("reponame")
-		queryString := ctx.URI().QueryArgs()
-		branch := string(queryString.Peek("branch"))
-		debug := string(queryString.Peek("debug"))
-
-		logrus.Debug("branch: %v - debug: %v", branch, debug)
-		badges, err := checkBadges(username, reponame, branch)
-		if err != nil {
-			ctx.Write(err.Error())
-			ctx.SetStatusCode(iris.StatusInternalServerError)
-		}
-		if debug == "true" {
-			htmlBadges := blackfriday.MarkdownBasic([]byte(strings.Join(badges[1:], "\n")))
-			htmlBadges = bluemonday.UGCPolicy().SanitizeBytes(htmlBadges)
-			if len(htmlBadges) == 0 {
-				htmlBadges = []byte("<p><em>No badges found in README.md</em></p>")
-			}
-
-			if err := ctx.Render("index.html", Badge{
-				BadgesHTML: template.HTML(string(htmlBadges)),
-				Badge:      badges[0],
-			}); err != nil {
-				logrus.Panic(err)
-			}
-		} else {
-			ctx.ServeFile(badges[0], false)
-		}
-	})
-
-	logrus.Info("Server listening on :8080")
+	iris.Get("/github.com/:username/:reponame", handleReport)
+	iris.Get("/report/github.com/:username/:reponame", handleReport)
+	// logrus.Debug("Server listening on :8080")
 	iris.Listen(":8080")
+}
 
+func handleReport(ctx *iris.Context) {
+	username := ctx.Param("username")
+	reponame := ctx.Param("reponame")
+	queryString := ctx.URI().QueryArgs()
+	branch := string(queryString.Peek("branch"))
+	debug := string(queryString.Peek("debug"))
+	uri := string(ctx.RequestURI())
+	pathSlice := strings.Split(uri, "/")
+	if pathSlice[1] == "report" {
+		debug = "true"
+	}
+
+	logrus.Debug("branch: %v - debug: %v", branch, debug)
+	badges, err := checkBadges(username, reponame, branch)
+	if err != nil {
+		ctx.Write(err.Error())
+		ctx.SetStatusCode(iris.StatusInternalServerError)
+	}
+	if debug == "true" {
+		htmlBadges := blackfriday.MarkdownBasic([]byte(strings.Join(badges[1:], "\n")))
+		htmlBadges = bluemonday.UGCPolicy().SanitizeBytes(htmlBadges)
+		if len(htmlBadges) == 0 {
+			htmlBadges = []byte("<p><em>No badges found in README.md</em></p>")
+		}
+
+		if err := ctx.Render("index.html", Badge{
+			BadgesHTML: template.HTML(string(htmlBadges)),
+			Badge:      badges[0],
+		}); err != nil {
+			logrus.Panic(err)
+		}
+	} else {
+		ctx.ServeFile(badges[0], false)
+	}
 }


### PR DESCRIPTION
Created a new endpoint to allow the `/report/` to be used as a link for the badge. 
This allows a user to have a clean debug url such as:
`doyouevenbadge.com/report/github.com/stevvooe/badgebadge`
Signed-off-by: French Ben frenchben@docker.com
